### PR TITLE
Feature/redux opinionated

### DIFF
--- a/shared/components/DemoApp/AsyncAboutRoute/__tests__/AboutRoute.test.js
+++ b/shared/components/DemoApp/AsyncAboutRoute/__tests__/AboutRoute.test.js
@@ -6,6 +6,10 @@ import { shallow } from 'enzyme';
 import AboutRoute from '../AboutRoute';
 
 describe('<AboutRoute />', () => {
+  test('renders both paragraph text', () => {
+    const wrapper = shallow(<AboutRoute />);
+    expect(wrapper.find('p').length).toBe(2);
+  });
   test('renders', () => {
     const wrapper = shallow(<AboutRoute />);
     expect(wrapper).toMatchSnapshot();

--- a/shared/components/DemoApp/AsyncHomeRoute/__tests__/HomeRoute.test.js
+++ b/shared/components/DemoApp/AsyncHomeRoute/__tests__/HomeRoute.test.js
@@ -6,6 +6,14 @@ import { shallow } from 'enzyme';
 import HomeRoute from '../HomeRoute';
 
 describe('<HomeRoute />', () => {
+  test('renders paragraph text', () => {
+    const wrapper = shallow(<HomeRoute />);
+    expect(wrapper.find('p').length).toBe(1);
+  });
+  test('renders h2 element', () => {
+    const wrapper = shallow(<HomeRoute />);
+    expect(wrapper.find('h2').length).toBe(1);
+  });
   test('renders', () => {
     const wrapper = shallow(<HomeRoute />);
     expect(wrapper).toMatchSnapshot();

--- a/shared/components/DemoApp/AsyncPostsRoute/Post/Post.js
+++ b/shared/components/DemoApp/AsyncPostsRoute/Post/Post.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes, { string } from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withJob } from 'react-jobs';
@@ -6,7 +7,7 @@ import Helmet from 'react-helmet';
 import * as PostActions from '../../../../actions/posts';
 import * as FromState from '../../../../reducers';
 
-function Post({ post }) {
+export function Post({ post }) {
   if (!post) {
     // Post hasn't been fetched yet. It would be better if we had a "status"
     // reducer attached to our posts which gave us a bit more insight, such
@@ -72,7 +73,10 @@ export default compose(
 )(Post);
 
 Post.propTypes = {
-  post: PropTypes.shape(PropTypes.any),
+  post: PropTypes.shape({
+    title: string,
+    body: string,
+  }),
 };
 
 Post.defaultProps = {

--- a/shared/components/DemoApp/AsyncPostsRoute/Post/__tests__/Post.test.js
+++ b/shared/components/DemoApp/AsyncPostsRoute/Post/__tests__/Post.test.js
@@ -1,0 +1,22 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Post } from '../Post';
+
+const FakePost = {
+  title: 'Test',
+  body: 'Test this post',
+};
+
+describe('<Post />', () => {
+  test('renders header', () => {
+    const wrapper = shallow(<Post post={FakePost} />);
+    expect(wrapper.find('h1').length).toBe(1);
+  });
+  test('renders the snapshot', () => {
+    const wrapper = shallow(<Post post={FakePost} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/shared/components/DemoApp/AsyncPostsRoute/Post/__tests__/__snapshots__/Post.test.js.snap
+++ b/shared/components/DemoApp/AsyncPostsRoute/Post/__tests__/__snapshots__/Post.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<HomeRoute /> renders the snapshot 1`] = `
+<div>
+  <HelmetWrapper
+    encodeSpecialCharacters={true}
+    title="Posts - Test"
+  />
+  <h1>
+    Test
+  </h1>
+  <div>
+    Test this post
+  </div>
+</div>
+`;

--- a/shared/components/DemoApp/AsyncPostsRoute/Post/__tests__/__snapshots__/Post.test.js.snap
+++ b/shared/components/DemoApp/AsyncPostsRoute/Post/__tests__/__snapshots__/Post.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<HomeRoute /> renders the snapshot 1`] = `
+exports[`<Post /> renders the snapshot 1`] = `
 <div>
   <HelmetWrapper
     encodeSpecialCharacters={true}

--- a/shared/reducers/posts/__tests__/all.test.js
+++ b/shared/reducers/posts/__tests__/all.test.js
@@ -1,0 +1,7 @@
+import all from '../all';
+
+describe('Posts - all reducer', () => {
+  it('Should return the initial state', () => {
+    expect(all(undefined, {})).toEqual([]);
+  });
+});

--- a/shared/reducers/posts/__tests__/byId.test.js
+++ b/shared/reducers/posts/__tests__/byId.test.js
@@ -1,0 +1,7 @@
+import byId from '../byId';
+
+describe('Posts - byId reducer', () => {
+  it('Should return the initial state', () => {
+    expect(byId(undefined, {})).toEqual({});
+  });
+});

--- a/shared/reducers/posts/__tests__/index.test.js
+++ b/shared/reducers/posts/__tests__/index.test.js
@@ -1,0 +1,10 @@
+import posts from '../index';
+
+describe('Posts reducer', () => {
+  it('Should return the initial state', () => {
+    expect(posts(undefined, {})).toEqual({
+      all: [],
+      byId: {},
+    });
+  });
+});


### PR DESCRIPTION
Removes reference to deprecated react PropTypes import and replaces with the prop-types package. 

Adds tests for Post route and all post reducers.

Improves tests for Home and About.