### PR TITLE
Fix Router v2 Implementation

### DIFF
--- a/shared/components/DemoApp/AsyncPostsRoute/Post/Post.js
+++ b/shared/components/DemoApp/AsyncPostsRoute/Post/Post.js
@@ -68,7 +68,7 @@ export default compose(
       return fetchPost(match.params.id);
     },
     // Any time the post id changes we need to trigger the work.
-    shouldWorkAgain: (prevProps, nextProps) => prevProps.params.id !== nextProps.params.id,
+    shouldWorkAgain: (prevProps, nextProps) => prevProps.match.params.id !== nextProps.match.params.id,
   }),
 )(Post);
 


### PR DESCRIPTION
After making some tweaks to this branch to change some things around, I found that the posts route did not have a `nextProps.params.id`, however it does have a `nextProps.match.params.id`. I think it might be safer to stick with `match` as that's the default object exposed by the router to it's child component.